### PR TITLE
Fix juju dependency bug for the release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 BUILD_DIRECTORY := ./build_directory
-MODEL_NAME := $(shell juju models --format=yaml | yq ".current-model")
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)
@@ -16,7 +15,7 @@ deploy: build
 	juju deploy $(BUILD_DIRECTORY)/mysql-k8s-bundle.zip --trust
 
 destroy-model:
-	juju destroy-model --force --destroy-storage $(MODEL_NAME)
+	juju destroy-model --force --destroy-storage $(shell juju models --format=yaml | yq ".current-model")
 
 release:
 	charmcraft upload $(BUILD_DIRECTORY)/*.zip


### PR DESCRIPTION
# Issue
The `release.yaml` workflow does not install `juju` as a dependency. However, the Makefile invokes a `juju` command upon every target being called. This `juju` command output is stored in a variable and only used in one makefile target.

# Solution
In-line the `juju` command invocation, so it is not necessary to install `juju` in the release workflow.

# Release Notes
Fix juju dependency bug for the release workflow
