### PR TITLE
Make sure to build when calling the release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ deploy: build
 destroy-model:
 	juju destroy-model --force --destroy-storage $(shell juju models --format=yaml | yq ".current-model")
 
-release:
+release: build
 	charmcraft upload $(BUILD_DIRECTORY)/*.zip
 	charmcraft release mysql-k8s-bundle --revision $(shell charmcraft revisions mysql-k8s-bundle | awk 'NR==2 {print $$1}') --channel=latest/edge


### PR DESCRIPTION
# Issue
We are not `build`ing when the `release` make target is called.

# Solution
Add a dependency of the `build` to ensure that we always `build` when we call `release`.

# Release Notes
Make sure to build when calling the release target