### PR TITLE
Upload and release to charmcraft in the same command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,4 @@ destroy-model:
 	juju destroy-model --force --destroy-storage $(shell juju models --format=yaml | yq ".current-model")
 
 release: build
-	charmcraft upload $(BUILD_DIRECTORY)/*.zip
-	charmcraft release mysql-k8s-bundle --revision $(shell charmcraft revisions mysql-k8s-bundle | awk 'NR==2 {print $$1}') --channel=latest/edge
+	charmcraft upload $(BUILD_DIRECTORY)/*.zip --name mysql-k8s-bundle --release=latest/edge


### PR DESCRIPTION
# Issue
In yet more `release` to charmhub drama, the following make target always evaluates revisions to 1 less than the uploaded revision:
```
release: build
    charmcraft upload $(BUILD_DIRECTORY)/*.zip
    charmcraft release mysql-k8s-bundle --revision $(shell charmcraft revisions mysql-k8s-bundle | awk 'NR==2 {print $$1}') --channel=latest/edge
```

# Solution
Upload and release to charmhub simultaneously in the same command using the `--name` and `--release` flags in the `charmhub upload` command.

# Release Notes
Upload and release to charmcraft in the same command
