### PR TITLE
Consider both risk and track for the charm when updating bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_DIRECTORY := ./build_directory
+BUILD_DIRECTORY := ./build
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)

--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -1,12 +1,12 @@
 applications:
   mysql-k8s:
-    channel: edge
+    channel: latest/edge
     charm: mysql-k8s
     constraints: arch=amd64
     revision: 15
     scale: 1
   mysql-router-k8s:
-    channel: edge
+    channel: latest/edge
     charm: mysql-router-k8s
     constraints: arch=amd64
     revision: 2

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -59,4 +59,4 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} \
-        --durations=0 --asyncio-mode=auto
+        --durations=0

--- a/tox.ini
+++ b/tox.ini
@@ -60,3 +60,4 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} \
         --durations=0
+

--- a/update_bundle.py
+++ b/update_bundle.py
@@ -18,11 +18,13 @@ def fetch_revision(charm, charm_channel):
         f"https://api.snapcraft.io/v2/charms/info/{charm}?fields=channel-map"
     ).json()
 
+    [track, risk] = charm_channel.split("/")
+
     for channel in charm_info["channel-map"]:
-        if channel["channel"]["risk"] == charm_channel:
+        if channel["channel"]["risk"] == risk and channel["channel"]["track"] == track:
             return channel["revision"]["revision"]
 
-    raise ValueError("Revision not found")
+    raise ValueError(f"Revision not found for {charm} on {charm_channel}")
 
 def update_bundle(bundle_path):
     """Updates a bundle's revision number."""


### PR DESCRIPTION
# Issue
1. We are not considering both `risk` and `track` of a charm when running the `update_bundle` script
2. We are pinning flake8 version (for an already resolved bug)

# Solution
1. Consider both `risk` and `track` of charm when trying to determine the latest revision for the charm's channel
2. Un-pin the flake8 version

# Release Notes
Consider both risk and track for the charm when updating bundle
