### PR TITLE
Pin flake8 version due to incompatibilities in v6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==5.0.4 # Pin due to compatibility issues with v6
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
# Issue
[jira ticket](https://warthogs.atlassian.net/browse/DPE-1018)
flake8 v6 breaks linting (due to incompatibilities with our flake8 modules)

# Solution
pin flake8 to v5.0.4

# Release Notes
Pin flake8 version due to incompatibilities in v6
