### PR TITLE
Increase timeout for mysql cluster bootstrap to stabilize GH CI/CD

### DIFF
--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -31,7 +31,7 @@ async def test_deploy_bundle(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.deploy("./releases/latest/mysql-k8s-bundle.yaml", trust=True)
 
-        await ops_test.model.wait_for_idle(apps=[MYSQL_APP], status="active", timeout=5 * 60)
+        await ops_test.model.wait_for_idle(apps=[MYSQL_APP], status="active", timeout=15 * 60)
 
         await ops_test.model.wait_for_idle(apps=[ROUTER_APP], status="waiting", timeout=5 * 60)
 


### PR DESCRIPTION
## Issue
GH CI/CD is failing often with timeout:

> INFO     juju.model:model.py:2530 Waiting for model:
>   mysql-k8s/0 [idle] active:
>   mysql-k8s/1 [idle] active:
>   mysql-k8s/2 [executing] maintenance: Executing restart operation
> FAILED

## Solution
Increase timeout for slow and busy GH runners.