### PR TITLE
Add badges to show the repo Status on https://releases.juju.is/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Canonical Distribution of MySQL + MySQLRouter
 
-[![None](https://charmhub.io/mysql-k8s-bundle/badge.svg)](https://charmhub.io/mysql-k8s-bundle)
+[![Update](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/on_bundle_update_available.yaml/badge.svg?branch=main)](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/on_bundle_update_available.yaml?query=branch%3Amain)
+[![Tests](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/ci.yaml/badge.svg?branch=main&event=schedule)](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/ci.yaml?query=branch%3Amain+event%3Aschedule)
+[![Release](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/release.yaml/badge.svg?branch=main&event=push)](https://github.com/canonical/mysql-k8s-bundle/actions/workflows/release.yaml?query=branch%3Amain+event%3Apush)
+[![Charmhub](https://charmhub.io/mysql-k8s-bundle/badge.svg)](https://charmhub.io/mysql-k8s-bundle)
 
 Welcome to the Canonical Distribution of MySQL + MySQLRouter.
 
@@ -55,11 +58,9 @@ juju add-model my-mysql-k8s && juju status
 
 ## Bundle Components
 
-[![MySQL](https://charmhub.io/mysql-k8s/badge.svg)](https://charmhub.io/mysql-k8s) [![MySQL Router](https://charmhub.io/mysql-router-k8s/badge.svg)](https://charmhub.io/mysql-router-k8s) [![TLS Certificates](https://charmhub.io/tls-certificates-operator/badge.svg)](https://charmhub.io/tls-certificates-operator)
-
-- [mysql-k8s](https://charmhub.io/mysql-k8s): A k8s charm to deploy MySQL with Group Replication.
-- [mysql-router-k8s](https://charmhub.io/mysql-router-k8s) - a k8s charm to deploy MySQL Router.
-- [tls-certificates-operator](https://charmhub.io/tls-certificates-operator) - TLS operator.
+- [![MySQL](https://charmhub.io/mysql-k8s/badge.svg)](https://charmhub.io/mysql-k8s) - K8s charm to deploy MySQL with Group Replication.
+- [![MySQL Router](https://charmhub.io/mysql-router-k8s/badge.svg)](https://charmhub.io/mysql-router-k8s) - K8s charm to deploy MySQL Router.
+- [![TLS Certificates](https://charmhub.io/tls-certificates-operator/badge.svg)](https://charmhub.io/tls-certificates-operator) - TLS operator.
 
 Note: The TLS settings in bundles use self-signed-certificates which are not recommended for production clusters, the tls-certificates-operator charm offers a variety of configurations, read more on the TLS charm [here](https://charmhub.io/tls-certificates-operator).
 


### PR DESCRIPTION
## Issue
We need a common board to monitor statuses for all our repos: https://releases.juju.is/

## Solution
Add badges as described in [this post](https://discourse.charmhub.io/t/you-needed-a-status-page-and-now-you-have-one/8756).