### PR TITLE
Update reviewers list and add workflow_dispatch

### DIFF
--- a/.github/workflows/on_bundle_update_available.yaml
+++ b/.github/workflows/on_bundle_update_available.yaml
@@ -3,6 +3,7 @@ name: Update bundle
 on:
   schedule:
     - cron:  '0 */8 * * 1-5'
+  workflow_dispatch:
 
 jobs:
   update-bundles:

--- a/.github/workflows/on_bundle_update_available.yaml
+++ b/.github/workflows/on_bundle_update_available.yaml
@@ -1,4 +1,4 @@
-name: bundle update available
+name: Update bundle
 
 on:
   schedule:
@@ -29,9 +29,5 @@ jobs:
             Update bundles with new revisions from Charmhub.
           labels: |
             automated pr
-          assignees: team-reviewers, shayancanonical, paulomach
-          reviewers: team-reviewers, paulomach
-          team-reviewers: |
-            owners
-            maintainers
+          reviewers: canonical/data-platform-mysql
           draft: false


### PR DESCRIPTION
## Issue
We have hardcoded list of GH users in our reviwers list, while we can use GH Team.

## Solution
Use GH Team and allow users to trigger update bundle checks manually.
