### PR TITLE
untrust router

### DIFF
--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -10,7 +10,7 @@ applications:
     channel: latest/edge
     charm: mysql-router-k8s
     constraints: arch=amd64
-    revision: 20
+    revision: 21
     scale: 1
   tls-certificates-operator:
     channel: latest/stable

--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -3,16 +3,15 @@ applications:
     channel: latest/edge
     charm: mysql-k8s
     constraints: arch=amd64
-    revision: 43
+    revision: 46
     scale: 3
     trust: true
   mysql-router-k8s:
     channel: latest/edge
     charm: mysql-router-k8s
     constraints: arch=amd64
-    revision: 19
+    revision: 20
     scale: 1
-    trust: true
   tls-certificates-operator:
     channel: latest/stable
     charm: tls-certificates-operator


### PR DESCRIPTION
## Issue

Router is being deployed with `trust` flag, which is unnecessary. 
[DPE-1131](https://warthogs.atlassian.net/browse/DPE-1131)

## Solution

Remove flag

### Chore

bump versions

**NOTE**: merge after router [PR#43](https://github.com/canonical/mysql-router-k8s-operator/pull/43)


[DPE-1131]: https://warthogs.atlassian.net/browse/DPE-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ