### PR TITLE
DPE-1656 Limit tests RAM usage by every unit/container to 1Gb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.42"
+          bootstrap-options: "--agent-version 2.9.42 --constraints mem=1G"
       - name: Run integration bundle test
         run: tox run -e integration -- --junit-xml=pytest_report.xml
       - name: 'Foresight: Collect test results'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
           provider: microk8s
           bootstrap-options: "--model-default 'logging-config=<root>=INFO;unit=DEBUG' --agent-version 2.9.42 --constraints mem=1G"
       - name: Run integration bundle test
-        run: tox run -e integration -- --junit-xml=pytest_report.xml
+        run: tox run -e integration -- --junit-xml=pytest_report.xml --keep-models
       - name: Setup upterm session
         if: success() || failure()
         uses: lhotari/action-upterm@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,15 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.42 --constraints mem=1G"
+          bootstrap-options: "--model-default 'logging-config=<root>=INFO;unit=DEBUG' --agent-version 2.9.42 --constraints mem=1G"
       - name: Run integration bundle test
         run: tox run -e integration -- --junit-xml=pytest_report.xml
+      - name: Setup upterm session
+        if: success() || failure()
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-actor: true
+          limit-access-to-users: taurus-forever
       - name: 'Foresight: Collect test results'
         uses: runforesight/foresight-test-kit-action@v1
         if: ${{ success() || failure() }}


### PR DESCRIPTION
## Issue
Often and strange tests crashes on GH runner while all is OK on localhost.

## Solution
GH Runners have 8GB RAM only. We are launching 1-2 MySQL clusters with three units each and allocating 50% for innodb_buffer_pull_size. OOM is an often trouble in this case.