### PR TITLE
Use exactly match on 'pgrep mysqld' due to mysqld_exporter availability

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -248,7 +248,7 @@ async def send_signal_to_pod_container_process(
 
     pod_name = unit_name.replace("/", "-")
 
-    send_signal_command = f"/charm/bin/pebble signal {signal_code} {process}"
+    send_signal_command = f"pkill -{signal_code} {process}"
     response = kubernetes.stream.stream(
         kubernetes.client.api.core_v1_api.CoreV1Api().connect_get_namespaced_pod_exec,
         pod_name,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -145,6 +145,7 @@ async def get_process_pid(
         container_name,
         unit_name,
         "pgrep",
+        "-x",
         process,
     ]
     return_code, pid, _ = await ops_test.juju(*get_pid_commands)

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -21,7 +21,7 @@ from tests.integration.helpers import (
 )
 
 MYSQL_CONTAINER_NAME = "mysql"
-MYSQLD_PROCESS_NAME = "mysqld_safe"
+MYSQLD_PROCESS_NAME = "mysqld"
 MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -21,7 +21,7 @@ from tests.integration.helpers import (
 )
 
 MYSQL_CONTAINER_NAME = "mysql"
-MYSQLD_PROCESS_NAME = "mysqld"
+MYSQLD_PROCESS_NAME = "mysqld_safe"
 MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Issue

The integration test is randomly crashing on GH with error:
```
> Traceback (most recent call last):
>   File "/home/runner/work/mysql-k8s-bundle/mysql-k8s-bundle/tests/integration/test_bundle.py", line 67, in test_mysql_primary_switchover
>     mysql_pid = await get_process_pid(
>   File "/home/runner/work/mysql-k8s-bundle/mysql-k8s-bundle/tests/integration/helpers.py", line 160, in get_process_pid
>     return int(stripped_pid)
> ValueError: invalid literal for int() with base 10: '69\n353\n409'
```

## Solution

Use pgrep with exact match flag (-x):
```
> ubuntu@juju-82de18-16:~$ pgrep -a mysqld
> 3774 /snap/charmed-mysql/24/bin/mysqld_exporter ...
> 3996 /bin/sh /snap/charmed-mysql/24/usr/bin/mysqld_safe ...
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$
    
> ubuntu@juju-82de18-16:~$ pgrep -a -x mysqld
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$
```