### PR TITLE
[MISC] Pin grafana-agent-k8s channel to `1/edge`

### DIFF
--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -6,7 +6,7 @@ applications:
     revision: 113
     scale: 1
   grafana-agent-k8s:
-    channel: latest/edge
+    channel: 1/edge
     charm: grafana-agent-k8s
     constraints: arch=amd64
     resources:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,10 +1,22 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import Dict
+from typing import Dict, Optional
 
 from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
+
+
+async def get_leader_unit(ops_test: OpsTest, app_name: str) -> Optional[Unit]:
+    """Get the leader unit of a given application.
+
+    Args:
+        ops_test: The ops test framework instance
+        app_name: The name of the application
+    """
+    for unit in ops_test.model.applications[app_name].units:
+        if await unit.is_leader_from_status():
+            return unit
 
 
 async def get_unit_ip(ops_test: OpsTest, unit_name: str) -> str:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -11,7 +11,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from .connector import MysqlConnector
-from .helpers import get_credentials, get_unit_ip
+from .helpers import get_credentials, get_leader_unit, get_unit_ip
 
 waiting_apps = [
     "mysql-router-k8s",
@@ -91,14 +91,14 @@ async def test_smoke(ops_test: OpsTest) -> None:
         await ensure_statuses(ops_test)
 
         logger.info("Confirming data-integrator's database exists")
-        mysql_unit = ops_test.model.applications["mysql-k8s"].units[0]
-        mysql_unit_address = await get_unit_ip(ops_test, mysql_unit.name)
-        server_config_credentials = await get_credentials(mysql_unit, "serverconfig")
+        mysql_leader = await get_leader_unit(ops_test, "mysql-k8s")
+        mysql_leader_address = await get_unit_ip(ops_test, mysql_leader.name)
+        server_config_credentials = await get_credentials(mysql_leader, "serverconfig")
 
         database_config = {
             "user": server_config_credentials["username"],
             "password": server_config_credentials["password"],
-            "host": mysql_unit_address,
+            "host": mysql_leader_address,
             "raise_on_warnings": False,
         }
 


### PR DESCRIPTION
The Observability team removed the `latest/edge` track as of Friday June 20. Channels will now be prefixed by the charm major versions (i.e. `1/...`, `2/...`). See:

- June 20th: Last [CI run](https://github.com/canonical/mysql-k8s-bundle/actions/runs/15769120919) where smoke integration tests passed.
- June 21th: First [CI run](https://github.com/canonical/mysql-k8s-bundle/actions/runs/15790592499) where smoke integration tests failed.