### PR TITLE
[DPE-7421] Add MySQL legacy interface test

### DIFF
--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -25,7 +25,7 @@ applications:
         # oci-image: docker://registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
         # oci-password: MDAxOGxvY2F0aW9uIGNoYXJtc3RvcmUKMDAzMGlkZW50aWZpZXIgOTBlODUwYWU2MzllNTZmMGU2OTc5MmYyOTQzZWY4ZDYKMDA0ZmNpZCBpcy1kb2NrZXItcmVwbyBjaGFybS82MnB0ZGZicmpwdzNuOXRjbnN3anBhcnQzMGphdWM2d2M1d2JpL215c3FsLWltYWdlCjAwMTNjaWQgYWxsb3cgcHVsbAowMDJmc2lnbmF0dXJlIHj1JqCbvenHNXj5sZEaVddyBA8sErFPiGfMgTjm8nrGCg
         # oci-username: docker-registry
-    revision: 257
+    revision: 261
     scale: 3
     trust: true
   mysql-router-data-integrator:

--- a/releases/latest/mysql-k8s-bundle.yaml
+++ b/releases/latest/mysql-k8s-bundle.yaml
@@ -93,6 +93,8 @@ relations:
   - grafana-agent-k8s:metrics-endpoint
 - - mysql-k8s:logging
   - grafana-agent-k8s:logging-provider
+- - mysql-k8s:mysql-root
+  - mysql-test-app:mysql
 - - mysql-router-k8s:database
   - mysql-router-data-integrator:mysql
 - - mysql-router-k8s:grafana-dashboard


### PR DESCRIPTION
This PR adds the  `mysql-root` legacy interface to the tests, in order to make https://github.com/canonical/mysql-k8s-operator/issues/614 visible.

The idea is to relate the MySQL K8s and MySQL test app charms via the legacy `mysql-root` interface **before** the charms finish their deployment. Something that we missed in the MySQL K8s tests (see [example](https://github.com/canonical/mysql-k8s-operator/blob/84deb1fb0cf69eaf1a5a87ba4907b6b2178bd255/tests/integration/relations/test_mysql_root.py#L165-L170)), which only relate applications through the legacy interface **after** the involved charms have been properly deployed.

