### PR TITLE
[MISC] Fix update-bundle GHA workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>canonical/data-platform//renovate_presets/charm.json5"],
-  "reviewers": ["team:data-platform-mysql"],
+  "reviewers": ["team:data-mysql"],
   "packageRules": [
     // Later rules override earlier rules
 

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -12,6 +12,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v35.0.2
     with:
       path-to-bundle-file: releases/latest/mysql-k8s-bundle.yaml
-      reviewers: canonical/data-platform-mysql
+      reviewers: canonical/data-mysql
     secrets:
       token: ${{ secrets.PAT }}


### PR DESCRIPTION
This PR fixes the `update-bundle` GHA workflow (see [failing runs](https://github.com/canonical/mysql-bundle/actions/workflows/update_bundle.yaml)). The MySQL team name changed some time in the past.
